### PR TITLE
Migrate to GH actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,25 @@
+name: Ruby
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test_and_coverage:
+
+    runs-on: ubuntu-latest
+    name: Ruby Test
+    strategy:
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # Runs bundle install and caches gems. See the ruby_test.yml
+                            # example if you need more control over bundler.
+    - name: Test
+      run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.6

--- a/pmb-client.gemspec
+++ b/pmb-client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest"
 
   spec.add_dependency "json_api_client", "~> 1.1"


### PR DESCRIPTION
This is currently of questionable usage, as the test suite is
just the templated out version. Still, it does more than the
travis tests, which literally just installed bundler.

However, the entire gem is pretty much just configuration
and boiler-plate, so there isn't a huge amount to test. Plus
with the planned migration to the V2 api, the gem will either be
dropped, or significantly re-worked shortly.

Closes #

Changes proposed in this pull request:

*
*
* ...
